### PR TITLE
Fix bug where enumerator for stateful collection is wrong

### DIFF
--- a/simplic-corelib/Simplic.CoreLib/Collections/Generic/StatefulCollection.cs
+++ b/simplic-corelib/Simplic.CoreLib/Collections/Generic/StatefulCollection.cs
@@ -167,7 +167,7 @@ namespace Simplic.Collections.Generic
             }
             foreach (var item in items)
             {
-                yield return newItems;
+                yield return item;
             }
         }
 

--- a/simplic-corelib/Simplic.CoreLib/Properties/AssemblyInfo.cs
+++ b/simplic-corelib/Simplic.CoreLib/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Sie können alle Werte angeben oder die standardmäßigen Build- und Revisionsnummern 
 // übernehmen, indem Sie "*" eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.1.118.621")]
-[assembly: AssemblyFileVersion("6.1.118.621")]
+[assembly: AssemblyVersion("6.1.218.719")]
+[assembly: AssemblyFileVersion("6.1.218.719")]


### PR DESCRIPTION
This is a huge bug, which breaks some python scripts and linq statements. I've no idea why this has been appeared earlier. Because this is used nearly everywhere, please check the changes.