### PR TITLE
added missing method for string format

### DIFF
--- a/simplic-localization/Simplic.Localization/Interface/ILocalizationService.cs
+++ b/simplic-localization/Simplic.Localization/Interface/ILocalizationService.cs
@@ -16,6 +16,14 @@ namespace Simplic.Localization
         string Translate(string key);
 
         /// <summary>
+        /// Translates a key formatted to a language
+        /// </summary>
+        /// <param name="key">Key to translate</param>
+        /// <param name="formatValues">Values to put in the string interpolation</param>
+        /// <returns>Translated formatted text</returns>
+        string Translate(string key, params string[] formatValues);
+
+        /// <summary>
         /// Changes the current language
         /// </summary>
         /// <param name="language">Language to change</param>

--- a/simplic-localization/Simplic.Localization/Properties/AssemblyInfo.cs
+++ b/simplic-localization/Simplic.Localization/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.0.18.619")]
-[assembly: AssemblyFileVersion("6.0.18.619")]
+[assembly: AssemblyVersion("6.0.118.913")]
+[assembly: AssemblyFileVersion("6.0.118.913")]


### PR DESCRIPTION
I've checked the following points:

- [x] I've formatted the code by pressing (STRG + K + D)
- [x] I've removed unnecessary usings
- [x] I've not used magic variables
- [x] I've used localization service instead of text
- [x] All `public` things have comments
- [x] This has been followed: [conventions](https://simplic.github.io/dev/csharp/getting_started/conventions.html)